### PR TITLE
Avoid double-closing channels

### DIFF
--- a/multiplex.go
+++ b/multiplex.go
@@ -238,8 +238,10 @@ func (mp *Multiplex) handleIncoming() {
 			if msch.closedLocal {
 				delete(mp.channels, ch)
 			}
-			msch.closedRemote = true
-			close(msch.dataIn)
+			if !msch.closedRemote {
+				msch.closedRemote = true
+				close(msch.dataIn)
+			}
 			msch.clLock.Unlock()
 			mp.chLock.Unlock()
 		default:

--- a/multiplex.go
+++ b/multiplex.go
@@ -22,7 +22,6 @@ const (
 	NewStream = iota
 	Receiver
 	Initiator
-	CloseLocal
 	Close
 )
 
@@ -228,7 +227,7 @@ func (mp *Multiplex) handleIncoming() {
 				return
 			}
 
-		case Close, CloseLocal:
+		case Close:
 			if !ok {
 				continue
 			}

--- a/stream.go
+++ b/stream.go
@@ -35,17 +35,6 @@ func (s *Stream) Name() string {
 	return s.name
 }
 
-func (s *Stream) receive(b []byte) {
-	s.clLock.Lock()
-	remoteClosed := s.closedRemote
-	s.clLock.Unlock()
-	if remoteClosed {
-		log.Errorf("Received data from remote after stream was closed by them. (len = %d)", len(b))
-		return
-	}
-	s.dataIn <- b
-}
-
 func (s *Stream) waitForData(ctx context.Context) error {
 	if !s.rDeadline.IsZero() {
 		dctx, cancel := context.WithDeadline(ctx, s.rDeadline)


### PR DESCRIPTION
This was causing us to:

1. Panic.
2. Try to close the stream.
3. Try to re-take the lock while closing the stream (and deadlock).

fixes ipfs/go-ipfs#4038