### PR TITLE
Fix a few deadlocks, panics, and leaks.

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.2.8: QmRWT7HgGeMovh1MUiidWFj9i96DjH5KXPmQWkPQDefxHG
+0.2.9: QmbX2bvPnLs2xPoJcFV7LHyn8bh3hxzwRaoEsZpmgP5hXn

--- a/multiplex.go
+++ b/multiplex.go
@@ -238,8 +238,10 @@ func (mp *Multiplex) handleIncoming() {
 			if msch.closedLocal {
 				delete(mp.channels, ch)
 			}
-			msch.closedRemote = true
-			close(msch.dataIn)
+			if !msch.closedRemote {
+				msch.closedRemote = true
+				close(msch.dataIn)
+			}
 			msch.clLock.Unlock()
 			mp.chLock.Unlock()
 		default:

--- a/multiplex.go
+++ b/multiplex.go
@@ -22,7 +22,6 @@ const (
 	NewStream = iota
 	Receiver
 	Initiator
-	CloseLocal
 	Close
 )
 
@@ -228,7 +227,7 @@ func (mp *Multiplex) handleIncoming() {
 				return
 			}
 
-		case Close, CloseLocal:
+		case Close:
 			if !ok {
 				continue
 			}

--- a/multiplex_test.go
+++ b/multiplex_test.go
@@ -221,6 +221,20 @@ func TestHalfClose(t *testing.T) {
 	mpb.Close()
 }
 
+func TestFuzzCloseConnection(t *testing.T) {
+	a, b := net.Pipe()
+
+	for i := 0; i < 1000; i++ {
+		mpa := NewMultiplex(a, false)
+		mpb := NewMultiplex(b, true)
+
+		go mpa.Close()
+		go mpa.Close()
+
+		mpb.Close()
+	}
+}
+
 func TestClosing(t *testing.T) {
 	a, b := net.Pipe()
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "license": "",
   "name": "go-multiplex",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.2.8"
+  "version": "0.2.9"
 }
 

--- a/stream.go
+++ b/stream.go
@@ -35,17 +35,6 @@ func (s *Stream) Name() string {
 	return s.name
 }
 
-func (s *Stream) receive(b []byte) {
-	s.clLock.Lock()
-	remoteClosed := s.closedRemote
-	s.clLock.Unlock()
-	if remoteClosed {
-		log.Errorf("Received data from remote after stream was closed by them. (len = %d)", len(b))
-		return
-	}
-	s.dataIn <- b
-}
-
 func (s *Stream) waitForData(ctx context.Context) error {
 	if !s.rDeadline.IsZero() {
 		dctx, cancel := context.WithDeadline(ctx, s.rDeadline)


### PR DESCRIPTION
Please review this commit-by-commit. It fixes a few panics, deadlocks, and
leaks:

* Panic: Double close of dataIn channel for streams when receiving two Close messages
from the remote peer.
* Panic: Concurrent calls to Close on the connection would panic (double channel
  close).
* Leak: Make sure to deregister fully close all streams when closing the
  connection.
* Deadlock: Make stream.Read return when closing the connection by closing the
  `dataIn` channel.

There are also some other random cleanups.

This should fix many of the CI stalls seen in go-ipfs.