### PR TITLE
fix double close of channel

### DIFF
--- a/multiplex_test.go
+++ b/multiplex_test.go
@@ -48,17 +48,15 @@ func TestSlowReader(t *testing.T) {
 		t.Fatal("wrote too many messages")
 	}
 
-	// Read exactly 8.
+	// There's a race between reading this stream and processing the reset
+	// so we have to read enough off to drain the queue.
 	for i := 0; i < 8; i++ {
 		_, err = sb.Read(mes)
 		if err != nil {
-			t.Fatal(err)
+			return
 		}
 	}
-	_, err = sb.Read(mes)
-	if err == nil {
-		t.Fatal("stream should have been reset")
-	}
+	t.Fatal("stream should have been reset")
 }
 
 func TestBasicStreams(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -47,6 +47,8 @@ func (s *Stream) waitForData(ctx context.Context) error {
 
 	select {
 	case <-s.reset:
+		// This is the only place where it's safe to return these.
+		s.returnBuffers()
 		return fmt.Errorf("stream reset")
 	case read, ok := <-s.dataIn:
 		if !ok {
@@ -57,6 +59,28 @@ func (s *Stream) waitForData(ctx context.Context) error {
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+func (s *Stream) returnBuffers() {
+	if s.exbuf != nil {
+		mpool.ByteSlicePool.Put(uint32(cap(s.exbuf)), s.exbuf)
+		s.exbuf = nil
+		s.extra = nil
+	}
+	for {
+		select {
+		case read, ok := <-s.dataIn:
+			if !ok {
+				return
+			}
+			if read == nil {
+				continue
+			}
+			mpool.ByteSlicePool.Put(uint32(cap(read)), read)
+		default:
+			return
+		}
 	}
 }
 

--- a/stream.go
+++ b/stream.go
@@ -29,6 +29,9 @@ type Stream struct {
 	clLock       sync.Mutex
 	closedLocal  bool
 	closedRemote bool
+
+	// Closed when the connection is reset.
+	reset chan struct{}
 }
 
 func (s *Stream) Name() string {
@@ -41,7 +44,10 @@ func (s *Stream) waitForData(ctx context.Context) error {
 		defer cancel()
 		ctx = dctx
 	}
+
 	select {
+	case <-s.reset:
+		return fmt.Errorf("stream reset")
 	case read, ok := <-s.dataIn:
 		if !ok {
 			return io.EOF
@@ -142,7 +148,7 @@ func (s *Stream) Reset() error {
 	}
 
 	if !s.closedRemote {
-		close(s.dataIn)
+		close(s.reset)
 		// We generally call this to tell the other side to go away. No point in waiting around.
 		go s.mp.sendMsg(s.id<<3|Reset+s.initiator, nil, time.Time{})
 	}


### PR DESCRIPTION
Instead of closing the dataIn on reset, close a second `reset` channel
that's never written to.

Also:

* try to reclaim buffers from reset stream on read
* make read deadlines cleaner